### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -14,10 +14,10 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Install Rust Stable
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af  # v1
         with:
           toolchain: stable
           components: rustfmt, clippy
@@ -29,31 +29,31 @@ jobs:
 
       - name: Install cargo-readme for Ubuntu
         if: matrix.os == 'ubuntu-latest'
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505  # v1
         with:
           command: install
           args: cargo-readme
 
       - name: Build
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505  # v1
         with:
           command: build
           args: --all-targets --verbose
 
       - name: Lint with RustFmt
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505  # v1
         with:
           command: fmt
           args: -- --check
 
       - name: Lint with Clippy
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505  # v1
         with:
           command: clippy
           args: --all-targets --all-features -- -D warnings
 
       - name: Run tests
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505  # v1
         with:
           command: test
           args: --verbose


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `rust.yaml` | `actions/checkout` | `v1` | `v6.0.2` | `de0fac2e4500…` |
| `rust.yaml` | `actions-rs/toolchain` | `v1` | `v1` | `16499b5e05bf…` |
| `rust.yaml` | `actions-rs/cargo` | `v1` | `v1` | `844f36862e91…` |
| `rust.yaml` | `actions-rs/cargo` | `v1` | `v1` | `844f36862e91…` |
| `rust.yaml` | `actions-rs/cargo` | `v1` | `v1` | `844f36862e91…` |
| `rust.yaml` | `actions-rs/cargo` | `v1` | `v1` | `844f36862e91…` |
| `rust.yaml` | `actions-rs/cargo` | `v1` | `v1` | `844f36862e91…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#267